### PR TITLE
Master

### DIFF
--- a/src/view/node.js
+++ b/src/view/node.js
@@ -82,13 +82,15 @@ Node.prototype._getEl = function () {
  *
  * @protected
  */
-Node.prototype._toAttached = function () {
+Node.prototype._toAttached = function (isChild) {
     each(this.childs, function (child) {
-        child._toAttached();
+        child._toAttached(true);
     });
 
     if (!this.lifeCycle.is('attached')) {
-        this._toPhase('created');
+        if (isChild) {
+            this._toPhase('created');
+        }
         if (this._attached) {
             this._attached();
         }

--- a/tool/build.js
+++ b/tool/build.js
@@ -67,7 +67,7 @@ function build() {
             ast.compute_char_frequency();
             ast.mangle_names();
 
-            editionSource = ast.print_to_string();
+            editionSource = ast.print_to_string({screw_ie8: false});
         }
 
         fs.writeFileSync(


### PR DESCRIPTION
由于 uglify 没有设置 screw_ie8 选项，在 build 后，由于压缩导致
*/dist/san.min.js*，*/dist/san.dev.min.js*，*/dist/san.spa.min.js*
中对象的键名的引号均被去掉，导致在 IE6-8 中由 class / for 等保留字做键名的对象抛出错误。