### PR TITLE
解决 class / for 保留字做键名时 uglify 后在 IE 下报错的问题

### DIFF
--- a/tool/build.js
+++ b/tool/build.js
@@ -67,7 +67,7 @@ function build() {
             ast.compute_char_frequency();
             ast.mangle_names();
 
-            editionSource = ast.print_to_string();
+            editionSource = ast.print_to_string({screw_ie8: false});
         }
 
         fs.writeFileSync(


### PR DESCRIPTION
由于 uglify 没有设置 screw_ie8 选项，在 build 后部分被 uglify 压缩的文件中的对象键名的引号被去掉，导致在 IE6-8 中使用 class / for 等保留字做键名的对象抛出错误。