### PR TITLE
Add missing screw_ie8 options

### DIFF
--- a/tool/build.js
+++ b/tool/build.js
@@ -59,13 +59,13 @@ function build() {
 
         if (option.compress) {
             let ast = uglifyJS.parse(editionSource);
-            ast.figure_out_scope();
-            ast = ast.transform(new uglifyJS.Compressor());
+            ast.figure_out_scope({screw_ie8: false});
+            ast = ast.transform(new uglifyJS.Compressor({screw_ie8: false}));
 
             // need to figure out scope again so mangler works optimally
-            ast.figure_out_scope();
-            ast.compute_char_frequency();
-            ast.mangle_names();
+            ast.figure_out_scope({screw_ie8: false});
+            ast.compute_char_frequency({screw_ie8: false});
+            ast.mangle_names({screw_ie8: false});
 
             editionSource = ast.print_to_string({screw_ie8: false});
         }


### PR DESCRIPTION
之前的配置，生成的 *.min.js 在 ie8 下面是无法运行的。`for, class, x.else` 这些情况没有处理