### PR TITLE
提高 defineComponet 方法友好性，避免重复定义，异常使用抛错

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ errorShots/
 /test/index-ssr.html
 /test/ssr/ssr.spec.js
 /test/pref/tti.html
+*.vscode

--- a/src/view/define-component.js
+++ b/src/view/define-component.js
@@ -13,6 +13,15 @@ var inherits = require('../util/inherits');
  * @return {Function}
  */
 function defineComponent(proto) {
+
+    if (typeof proto === 'function' && proto.prototype._type === 'component') {
+        return proto;
+    }
+
+    if (typeof proto !== 'object') {
+        throw new Error('[SAN FATAL] param must be a plain object.');
+    }
+
     function ComponentClass(option) {
         Component.call(this, option);
     }


### PR DESCRIPTION
在项目中，基于业务考量（e.g. **单组件size**），曾尝试将 san 的 **组件开发** 和 **运行时环境** 分离。在这种情况下，递归调用 san 包装器包装时，因 san 的`defineComponent`内部无检验逻辑，会存在重复定义风险。该 pull request 增加了包装器的内部校验逻辑，并对异常使用情形抛出错误，方便框架使用者定位问题。