### PR TITLE
优化一下昨天修复 #108 的问题

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -575,6 +575,12 @@ Component.prototype._dataChanger = function (change) {
     if (this.lifeCycle.is('painting') || this.lifeCycle.is('created')) {
         var len = this.dataChanges.length;
 
+        // 判断 change 类型是否是 SET，如果是则打一个标记，在后续 SPLICE 操作时不将这个 change 入栈
+        this.dataChanges.isChildsRebuild = this.dataChanges.isChildsRebuild || change.type === DataChangeType.SET;
+        if (change.type === DataChangeType.SPLICE && this.dataChanges.isChildsRebuild) {
+            return;
+        }
+
         if (!len) {
             nextTick(this._update, this);
         }

--- a/src/view/create-for.js
+++ b/src/view/create-for.js
@@ -342,8 +342,6 @@ function forOwnUpdate(changes) {
             && parentFirstChild === this.el
             && parentLastChild === this.el
 
-    var isChildsRebuild;
-
     each(changes, function (change) {
         var relation = changeExprCompare(change.expr, forDirective.list, this.scope);
 
@@ -434,10 +432,8 @@ function forOwnUpdate(changes) {
                     this.childs[i] = createForDirectiveChild(this, newList[i], i);
                 }
             }
-
-            isChildsRebuild = 1;
         }
-        else if (relation === 2 && change.type === DataChangeType.SPLICE && !isChildsRebuild) {
+        else if (relation === 2 && change.type === DataChangeType.SPLICE) {
             // 变更表达式是list绑定表达式本身数组的SPLICE操作
             // 此时需要删除部分项，创建部分项
             var changeStart = change.index;


### PR DESCRIPTION
昨天修复的方案 #109 欠考虑，直接在定位问题的位置忽略了 SPLICE 操作，之后想到这样做会产生多余的遍历。于是新的方案稍加改动，如果检测到一个 tick 里存在 SET 操作，那么 type 为
 SPLICE  的 change 将不会入栈，减少后续遍历 changes 的次数，提升了（可以忽略不计）的性能。