### PR TITLE
Fix121: 把 nextTick 函数的引用挂到 san 组件的实例上

### DIFF
--- a/src/view/component.js
+++ b/src/view/component.js
@@ -195,6 +195,13 @@ function Component(options) {
  */
 Component.prototype._type = NodeType.CMPT;
 
+/**
+ * 在下一个更新周期运行函数
+ *
+ * @param {Function} fn 要运行的函数
+ */
+Component.prototype.nextTick = nextTick;
+
 /* eslint-disable operator-linebreak */
 /**
  * 使节点到达相应的生命周期

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -119,6 +119,8 @@ describe("Component", function () {
         expect(labelAttached).toBe(1);
         expect(labelDetached).toBe(0);
 
+        expect(myComponent.nextTick).toBe(san.nextTick);
+
         myComponent.detach();
         expect(!!myComponent.lifeCycle.is('created')).toBe(true);
         expect(!!myComponent.lifeCycle.is('attached')).toBe(false);


### PR DESCRIPTION
刚本地merge 3.3.0-dev  发现似乎和主干是一样的，没merge下来新东西，不知道有没有问题~