### PR TITLE
resolve #128

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "test:sauce": "npm run test:e2e -- modern && npm run test:e2e -- ie_family && npm run test:e2e -- mobile",
     "build": "node ./tool/build.js"
   },
+  "types": "typings/san.d.ts",
   "main": "dist/san.ssr.js",
   "browser": "dist/san.dev.js",
   "unpkg": "dist/san.min.js",

--- a/typings/san.d.ts
+++ b/typings/san.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="typescript" />
+
+declare module 'san'


### PR DESCRIPTION
添加万用 declaration file，姑且照顾一下 ts 用户。

注：由于 san 的 export 没有使用 CommonJS 2 规范，ts 没办法把 san 对象当作 default export，因此在 ts 中引用的时候只能 `import * as san from 'san'` 而不能写作 `import san from 'san'`，这点可能需要在文档里注明。