### PR TITLE
feat: this.data.set() 支持设置整个 data 对象

### DIFF
--- a/src/parser/read-accessor.js
+++ b/src/parser/read-accessor.js
@@ -26,12 +26,12 @@ function readAccessor(walker) {
 
     var result = {
         type: ExprType.ACCESSOR,
-        paths: [
+        paths: firstSeg ? [
             {
                 type: ExprType.STRING,
                 value: firstSeg
             }
-        ]
+        ] : []
     };
 
     /* eslint-disable no-constant-condition */

--- a/src/parser/read-ident.js
+++ b/src/parser/read-ident.js
@@ -12,7 +12,7 @@
  */
 function readIdent(walker) {
     var match = walker.match(/\s*([\$0-9a-z_]+)/ig);
-    return match[1];
+    return match && match[1];
 }
 
 exports = module.exports = readIdent;

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -2838,5 +2838,25 @@ describe("Component", function () {
 
         document.body.removeChild(wrap);
     });
+
+    it("set entire data object", function () {
+        var MyComponent = san.defineComponent({
+            template: '<div><span class="text">hello {{name}}</span></div>'
+        });
+
+        var myComponent = new MyComponent();
+        var wrap = document.createElement('div');
+        document.body.appendChild(wrap);
+        myComponent.attach(wrap);
+
+        myComponent.data.set('', {name: 'San'});
+
+        san.nextTick(function () {
+            var span = wrap.getElementsByClassName('text');
+            expect(span[0].innerHTML).toBe('hello San');
+            document.body.removeChild(wrap);
+        });
+
+    });
 });
 


### PR DESCRIPTION
## 添加功能
`this.data.set()`支持设置整个data对象
## 使用方法
第一个参数设置为空字符串时，将第二个参数设置为 data 的值
```javascript
myComponent.data.set('', {name: 'San'});
```
## 用途
例如一个列表组件，`data` 中的数据大部分用于列表模板渲染，每次下拉刷新时需要修改 `data` 中的大量数据。通常需要获取到 `data` 中的多个项，依次修改后 `this.data.set()`，比较繁琐。

当前`this.data.get()`已经支持获取整个 `data` 对象，支持 `set` 整个 `data` 对象后，配合[immutability-helper](https://github.com/kolodny/immutability-helper)等库，可以在一个`update`中多处修改`data`。

```javascript
var newData = update(this.data.get(), {
    x: {
        $set: 7
    },
    a: {
        $push: [9]
    }
});
this.data.set('', newData);
```