### PR TITLE
为 template 添加更好的语法错误报错信息

### DIFF
--- a/src/parser/parse-template.js
+++ b/src/parser/parse-template.js
@@ -9,6 +9,19 @@ var Walker = require('./walker');
 var integrateAttr = require('./integrate-attr');
 var autoCloseTags = require('../browser/auto-close-tags');
 
+// #[begin] error
+function getXPath(stack, currentTagName) {
+    var path = ['ROOT'];
+    for (var i = 1, len = stack.length; i < len; i++) {
+        path.push(stack[i].tagName);
+    }
+    if (currentTagName) {
+        path.push(currentTagName);
+    }
+    return path.join('>');
+}
+// #[end]
+
 /* eslint-disable fecs-max-statements */
 
 /**
@@ -52,10 +65,31 @@ function parseTemplate(source, options) {
 
         // 62: >
         // 47: /
+        // 处理 </xxxx >
         if (tagEnd && walker.currentCode() === 62) {
             // 满足关闭标签的条件时，关闭标签
             // 向上查找到对应标签，找不到时忽略关闭
             var closeIndex = stackIndex;
+
+            // #[begin] error
+            // 如果正在闭合一个自闭合的标签，例如 </input>，报错
+            if (autoCloseTags[tagName]) {
+                throw new Error(''
+                    + '[SAN ERROR] ' + getXPath(stack, tagName) + ' is a `auto closed` tag, '
+                    + 'so it cannot be closed with </' + tagName + '>'
+                );
+            }
+
+            // 如果关闭的 tag 和当前打开的不一致，报错
+            if (
+                stack[closeIndex].tagName !== tagName
+                // 这里要把 table 自动添加 tbody 的情况给去掉
+                && !(tagName === 'table' && stack[closeIndex].tagName === 'tbody')
+            ) {
+                throw new Error('[SAN ERROR] ' + getXPath(stack) + ' is closed with ' + tagName);
+            }
+            // #[end]
+
             while (closeIndex > 0 && stack[closeIndex].tagName !== tagName) {
                 closeIndex--;
             }
@@ -65,9 +99,30 @@ function parseTemplate(source, options) {
                 stackIndex = closeIndex - 1;
                 currentNode = stack[stackIndex];
             }
-
             walker.go(1);
         }
+
+        // #[begin] error
+        // 处理 </xxx 非正常闭合标签
+        else if (tagEnd) {
+
+            // 如果闭合标签时，匹配后的下一个字符是 <，即下一个标签的开始，那么当前闭合标签未闭合
+            if (walker.currentCode() === 60) {
+                throw new Error(''
+                    + '[SAN ERROR] ' + getXPath(stack)
+                    + '\'s close tag not closed'
+                );
+            }
+
+            // 闭合标签有属性
+            throw new Error(''
+                + '[SAN ERROR] ' + getXPath(stack)
+                + '\'s close tag has attributes'
+            );
+
+        }
+        // #[end]
+
         else if (!tagEnd) {
             var aElement = createANode({
                 tagName: tagName
@@ -88,6 +143,7 @@ function parseTemplate(source, options) {
                     walker.go(1);
                     break;
                 }
+                // 遇到 /> 按闭合处理
                 else if (nextCharCode === 47
                     && walker.charCode(walker.index + 1) === 62
                 ) {
@@ -96,15 +152,37 @@ function parseTemplate(source, options) {
                     break;
                 }
 
+                // #[begin] error
+                // 在处理一个 open 标签时，如果遇到了 <， 即下一个标签的开始，则当前标签未能正常闭合，报错
+                if (nextCharCode === 60) {
+                    throw new Error('[SAN ERROR] ' + getXPath(stack, tagName) + ' is not closed');
+                }
+                // #[end]
+
                 // 读取 attribute
                 var attrMatch = walker.match(attrReg);
                 if (attrMatch) {
+
+                    // #[begin] error
+                    // 如果属性有 =，但没取到 value，报错
+                    if (
+                        walker.charCode(attrMatch.index + attrMatch[1].length) === 61
+                        && !attrMatch[2]
+                    ) {
+                        throw new Error(''
+                            + '[SAN ERROR] ' + getXPath(stack, tagName) + ' attribute `'
+                            + attrMatch[1] + '` is not wrapped with ""'
+                        );
+                    }
+                    // #[end]
+
                     integrateAttr(
                         aElement,
                         attrMatch[1],
                         attrMatch[2] ? attrMatch[4] : ''
                     );
                 }
+
             }
 
             // match if directive for else/elif directive

--- a/test/if-directive.spec.js
+++ b/test/if-directive.spec.js
@@ -1012,7 +1012,7 @@ describe("IfDirective", function () {
                     list: ['one', 'two']
                 };
             },
-            template: '<div><div san-if="condition"><u san-for="item,index in list" title="{{index}}{{item}}">{{index}}{{item}}</u></span></div>'
+            template: '<div><div san-if="condition"><u san-for="item,index in list" title="{{index}}{{item}}">{{index}}{{item}}</u></div></div>'
         });
 
         var myComponent = new MyComponent();

--- a/test/parse-template-error.spec.js
+++ b/test/parse-template-error.spec.js
@@ -1,0 +1,213 @@
+/**
+ * @file unit test for parser/parse-template.js
+ * @author leon <ludafa@outlook.com>
+ */
+
+/* globals san */
+
+describe('parseTemplate', function () {
+
+    var ALL_TAGS = [
+        "a", "abbr", "acronym", "address", "applet", "area", "article",
+        "aside", "audio", "b", "base", "basefont", "bdi", "bdo", "big",
+        "blockquote", "body", "br", "button", "canvas", "caption", "center",
+        "cite", "code", "col", "colgroup", "datalist", "dd", "del", "details",
+        "dfn", "dialog", "dir", "div", "dl", "dt", "em", "embed", "fieldset",
+        "figcaption", "figure", "font", "footer", "form", "frame", "frameset",
+        "h1", "h2", "h3", "h4", "h5", "h6",
+        "head", "header", "hr", "html", "i", "iframe", "img", "input",
+        "ins", "kbd", "label", "legend", "li", "link", "main", "map",
+        "mark", "menu", "menuitem", "meta", "meter", "nav", "noframes",
+        "noscript", "object", "ol", "optgroup", "option", "output", "p",
+        "param", "picture", "pre", "progress", "q", "rp", "rt", "ruby",
+        "s", "samp", "script", "section", "select", "small", "source",
+        "span", "strike", "strong", "style", "sub", "summary", "sup",
+        "table", "tbody", "td", "textarea", "tfoot", "th", "thead", "time",
+        "title", "tr", "track", "tt", "u", "ul", "var", "video", "wbr"
+    ];
+
+    var OPTIONAL_CLOSE_TAGS = [
+        "body", "colgroup", "dd", "dt", "head",
+        "html", "li", "option", "p", "tbody", "td", "tfoot", "th", "thead", "tr"
+    ];
+
+    var AUTO_CLOSE_TAGS = [
+        'area', 'base', 'br', 'col', 'embed', 'hr', 'img', 'input',
+        'keygen', 'param', 'source', 'track', 'wbr'
+    ];
+
+    var AUTO_CLOSE_TAGS_MAP = {};
+
+    for (var i = 0, len = AUTO_CLOSE_TAGS.length; i < len; i++) {
+        AUTO_CLOSE_TAGS_MAP[AUTO_CLOSE_TAGS[i]] = true;
+    }
+
+    var NOT_AUTO_CLOASE_TAGS = [];
+
+    for (var i = 0, len = ALL_TAGS.length; i < len; i++) {
+        if (!AUTO_CLOSE_TAGS_MAP[ALL_TAGS[i]]) {
+            NOT_AUTO_CLOASE_TAGS.push(ALL_TAGS[i]);
+        }
+    }
+
+    it('should throw error if open tag is not closed', function () {
+
+        for (var i = 0, len = ALL_TAGS.length; i < len; i++) {
+            var tag = ALL_TAGS[i];
+            expect(function () {
+                san.parseTemplate('<div> <' + tag + ' </div>');
+            }).toThrowError(
+                '[SAN ERROR] ROOT>div>' + tag + ' is not closed'
+            );
+        }
+
+    });
+
+    it('sholud throw error if close tag is not closed', function () {
+
+        // 只对非 auto-close 标签做此项校验，auto-close 标签有单独的校验
+        for (var i = 0, len = NOT_AUTO_CLOASE_TAGS.length; i < len; i++) {
+            var tag = NOT_AUTO_CLOASE_TAGS[i];
+            expect(function () {
+                san.parseTemplate('<div><' + tag + '></' + tag + ' </div>');
+            }).toThrowError(
+                '[SAN ERROR] ROOT>div>' + tag + '\'s close tag not closed'
+            );
+        }
+
+    });
+
+    it('should throw error if close tag have attributes', function () {
+
+        for (var i = 0, len = NOT_AUTO_CLOASE_TAGS.length; i < len; i++) {
+            var tag = NOT_AUTO_CLOASE_TAGS[i];
+            expect(function () {
+                san.parseTemplate(
+                    '<div><' + tag + '></' + tag + ' attr="1"> </div> '
+                );
+            }).toThrowError(
+                '[SAN ERROR] ROOT>div>' + tag + '\'s close tag has attributes'
+            );
+        }
+
+    });
+
+    it('should throw error if auto-close tag is closed with a </xxx>', function () {
+
+        for (var i = 0, len = AUTO_CLOSE_TAGS.length; i < len; i++) {
+            var tag = AUTO_CLOSE_TAGS[i];
+            expect(function () {
+                san.parseTemplate(
+                    '<div><' + tag + '>aaa</' + tag + '></div>'
+                );
+            }).toThrowError(''
+                + '[SAN ERROR] ROOT>div>' + tag + ' is a \`auto closed\` tag, '
+                + 'so it cannot be closed with </' + tag + '>'
+            );
+        }
+
+    });
+
+    it('should throw error if begin tag has no matching end tag', function () {
+
+        var rootName = 'some-tag-cannot-match';
+        for (var i = 0, len = NOT_AUTO_CLOASE_TAGS.length; i < len; i++) {
+
+            var tag = NOT_AUTO_CLOASE_TAGS[i];
+
+            expect(function() {
+                san.parseTemplate(''
+                    + '<' + rootName + '>'
+                    +     '<' + tag + '>'
+                    + '</' + rootName + '>'
+                );
+            }).toThrowError(''
+                + '[SAN ERROR] ROOT>' + rootName + '>' + tag
+                + ' is closed with ' + rootName
+            );
+
+            expect(function() {
+                san.parseTemplate(''
+                    + '<' + rootName + '>'
+                    +     '<' + tag + '></' + tag + '-you-shall-not-match>'
+                    + '</' + rootName + '>'
+                );
+            }).toThrowError(''
+                + '[SAN ERROR] ROOT>' + rootName + '>'
+                + tag + ' is closed with ' + tag + '-you-shall-not-match'
+            );
+        }
+
+    });
+
+    it('should pass checking auto generated tbody', function () {
+
+        expect(function () {
+            san.parseTemplate('<div><table><tr /></table></div>');
+        }).not.toThrow();
+
+    });
+
+    it('should not throw error if tag is forbidden to be closed(aka auto close tags)', () => {
+        expect(function () {
+
+            let tags = [];
+
+            for (let i = 0, len = AUTO_CLOSE_TAGS.length; i < len; i++) {
+                let tag = AUTO_CLOSE_TAGS[i];
+                tags.push('<' + tag + '><' + tag + '/>');
+            }
+
+            san.parseTemplate(''
+                + '<div>'
+                +     tags.join('')
+                + '</div>'
+            );
+
+        }).not.toThrow();
+    });
+
+    it('should throw error if tag is not closed correctly', function () {
+
+        expect(function () {
+            san.parseTemplate('<div><h1></h2></div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 is closed with h2');
+
+        expect(function () {
+            san.parseTemplate('<div> <h1><br></h2><aaa /> </div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 is closed with h2');
+
+        expect(function () {
+            san.parseTemplate('<div><h1>aa</div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 is closed with div');
+
+        expect(function () {
+            san.parseTemplate('<table> <tr></tr> </table>');
+        }).not.toThrow();
+
+    });
+
+    it('should throw error if attributes is not wrapped with "" or \'\'', function () {
+
+        expect(function () {
+            san.parseTemplate('<div> <h1 title=aaa></h1> </div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 attribute `title` is not wrapped with ""');
+
+        expect(function () {
+            san.parseTemplate('<div><h1 title="aaa></h1> </div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 attribute `title` is not wrapped with ""');
+
+        expect(function () {
+            san.parseTemplate('<div> <h1 title=aaa"></h1> </div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 attribute `title` is not wrapped with ""');
+
+        expect(function () {
+            san.parseTemplate('<div> <h1 title=\'aaa></h1> </div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 attribute `title` is not wrapped with ""');
+
+        expect(function () {
+            san.parseTemplate('<div> <h1 title=aaa\'></h1> </div>');
+        }).toThrowError('[SAN ERROR] ROOT>div>h1 attribute `title` is not wrapped with ""');
+    });
+
+});


### PR DESCRIPTION
为 template 添加更好的语法错误报错信息 #61

关于标签匹配，san template 应符合此规则：

html5 中规定不允许闭合的标签（自闭合标签）不强制闭合，其他标签必须闭合。

> 自闭合标签有
> `<area>` `<base>` `<br>` `<col>` `<embed>` `<hr>` 
> `<img>` `<input>` `<keygen>` `<param>` `<source>` `<track>` `<wbr>`

即对于自闭合标签这么写是可以接受的：

```html
<input > or <input />
```
但这个不行
```html
<input>xxx</input>
```
对于非自闭合标签，强制进行闭合：
```html
<li></li> or <li />
```

html 语法错误提示优化包含以下：

- [x] 属性值未包裹 例如 `<input value=xxx />`
- [x] 开始标签未闭合 例如 `<div<button/></div>`
- [x] 结束标签未闭合 例如 `<section><div>aaa</div</section>`
- [x] 结束标签包含属性 `<div></div class="xxx">`
- [x] 自闭合标签使用 `</xx>` 进行闭合，例如`<input>xxx</input>`
- [x] 开始标签与结束标签不匹配 `<div><h1></h2></div>`

其他的语法错误欢迎补充