### PR TITLE
修复两个 bug

### DIFF
--- a/src/view/create-for.js
+++ b/src/view/create-for.js
@@ -35,6 +35,7 @@ var nodeOwnCreateStump = require('./node-own-create-stump');
 var nodeOwnGetStumpEl = require('./node-own-get-stump-el');
 var elementDisposeChildren = require('./element-dispose-children');
 var warnSetHTML = require('./warn-set-html');
+var elementGetTransition = require('./element-get-transition')
 
 
 /**
@@ -510,7 +511,7 @@ function forOwnUpdate(changes) {
 
 
     // 清除应该干掉的 child
-    var violentClear = isOnlyParentChild && newChildrenLen === 0;
+    var violentClear = isOnlyParentChild && newChildrenLen === 0 && !elementGetTransition(me);
     var disposeChildCount = disposeChildren.length;
     var disposedChildCount = 0;
     each(disposeChildren, function (child) {
@@ -574,6 +575,11 @@ function forOwnUpdate(changes) {
 
             for (var i = 0; i < newChildrenLen; i++) {
                 var child = me.children[i];
+
+                // 防止 transition 钩子的 done 函数被执行两次时抛出异常
+                if (!child) {
+                    continue;
+                }
 
                 if (child.lifeCycle.attached) {
                     childrenChanges[i].length && child._update(childrenChanges[i]);


### PR DESCRIPTION
1. 在执行列表过渡动画时，如果列表被清空，过度动画将被忽略，实例会直接清空所有的 DOM 元素。
2. 在列表动画执行时，快速反复触发 leave 的钩子函数，可以观察到第一次 leave 的 done 函数执行后， child 被释放，当再次触发 done 函数时，将会抛出一个 child 不存在的异常。